### PR TITLE
Provide Docker support.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,7 @@
+FROM node:8.1
+
+WORKDIR /usr/app
+
+COPY package.json .
+RUN npm install --quiet
+COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM node:8.1
 
 WORKDIR /usr/app
+EXPOSE 6001
 
 COPY package.json .
 RUN npm install --quiet

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ A new mapping tool, this time sponsored by the [Leading Edge Forum](http://www.w
 
 The tool is running live [here](https://atlas2.wardleymaps.com).
 
+To test it out locally, you may run `docker-compose up` and visit http://localhost:6001.
+
 # Licence
 The code is licenced under creative commons (CC-BY-SA), except the LEF logo (atlas2/build-ui/img/LEF_logo.png).
 

--- a/app.js
+++ b/app.js
@@ -29,7 +29,7 @@ var mongoose = require('mongoose');
 var q = require('q');
 mongoose.Promise = q.Promise;
 var MongoDBConnection = require('./src-server/mongodb-helper');
-var conn = mongoose.createConnection(MongoDBConnection.connectionURL, MongoDBConnection.options);
+var conn = mongoose.createConnection(MongoDBConnection.atlas2.connectionURL, MongoDBConnection.atlas2.options);
 if (!(typeof global.it === 'function')) {
   require('./src-server/workspace/model/migrator')(conn);
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       - /usr/app/node_modules
     ports:
       - "6001:6001"
+    depends_on:
+      - mongo
     environment:
       DATABASE_URL: "mongodb://mongo"
   mongo:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,8 @@ services:
     depends_on:
       - mongo
     environment:
-      DATABASE_URL: "mongodb://mongo"
+      MONGO_URL_ATLAS2: "mongodb://mongo:27017/atlas2"
+      MONGO_URL_TEST_DUPLICATION: "mongodb://mongo:27017/test-duplication"
+      MONGO_URL_TEST_USAGE: "mongodb://mongo:27017/test-usage"
   mongo:
     image: mongo:3.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,14 @@
+version: '2'
+services:
+  web:
+    build: .
+    command: npm start
+    volumes:
+      - .:/usr/app/
+      - /usr/app/node_modules
+    ports:
+      - "8080:8080"
+    environment:
+      DATABASE_URL: "mongodb://mongo"
+  mongo:
+    image: mongo:3.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build: .
     command: npm start
     volumes:
-      - .:/usr/app/
+      - .:/usr/app/:Z
       - /usr/app/node_modules
     ports:
       - "6001:6001"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - .:/usr/app/
       - /usr/app/node_modules
     ports:
-      - "8080:8080"
+      - "6001:6001"
     environment:
       DATABASE_URL: "mongodb://mongo"
   mongo:

--- a/server-tests/duplication_tests.js
+++ b/server-tests/duplication_tests.js
@@ -21,7 +21,8 @@ var q = require('q');
 var owner = "testy@mactest.test";
 var mongoose = require('mongoose');
 mongoose.Promise = q.Promise;
-var mongooseConnection = mongoose.createConnection("mongodb://localhost:27017/test-duplication");
+var MongoDBConnection = require('../src-server/mongodb-helper');
+var mongooseConnection = mongoose.createConnection(MongoDBConnection.test_duplication.connectionURL);
 
 var WardleyMap = require('../src-server/workspace/model/map-schema')(mongooseConnection);
 var Workspace = require('../src-server/workspace/model/workspace-schema')(mongooseConnection);

--- a/server-tests/model-timeline-test.js
+++ b/server-tests/model-timeline-test.js
@@ -22,7 +22,8 @@ var q = require('q');
 var owner = "testy@mactest.test";
 var mongoose = require('mongoose');
 mongoose.Promise = q.Promise;
-var mongooseConnection = mongoose.createConnection("mongodb://localhost:27017/test-usage");
+var MongoDBConnection = require('../src-server/mongodb-helper');
+var mongooseConnection = mongoose.createConnection(MongoDBConnection.test_usage.connectionURL);
 
 var WardleyMap = require('../src-server/workspace/model/map-schema')(mongooseConnection);
 var Workspace = require('../src-server/workspace/model/workspace-schema')(mongooseConnection);

--- a/server-tests/model_tests.js
+++ b/server-tests/model_tests.js
@@ -20,9 +20,8 @@ var q = require('q');
 var owner = "testy@mactest.test";
 var mongoose = require('mongoose');
 mongoose.Promise = q.Promise;
-var mongooseConnection = mongoose.createConnection("mongodb://localhost:27017/test-usage");
-// var MongoDBConnectionURL = require('../src-server/mongodb-helper');
-// var mongooseConnection = mongoose.connect(MongoDBConnectionURL);
+var MongoDBConnection = require('../src-server/mongodb-helper');
+var mongooseConnection = mongoose.createConnection(MongoDBConnection.test_usage.connectionURL);
 
 var WardleyMap = require('../src-server/workspace/model/map-schema')(mongooseConnection);
 var Workspace = require('../src-server/workspace/model/workspace-schema')(mongooseConnection);

--- a/server-tests/workspace-migration-test.js
+++ b/server-tests/workspace-migration-test.js
@@ -26,9 +26,9 @@ var Number = Schema.Types.Number;
 var migrator = require('../src-server/workspace/model/workspace-schema').migrator;
 
 var owner = "testy@mactest.test";
-
-var mongooseConnection1 = mongoose.createConnection("mongodb://localhost:27017/test-usage");
-var mongooseConnection2 = mongoose.createConnection("mongodb://localhost:27017/test-usage");
+var MongoDBConnection = require('../src-server/mongodb-helper');
+var mongooseConnection1 = mongoose.createConnection(MongoDBConnection.test_usage.connectionURL);
+var mongooseConnection2 = mongoose.createConnection(MongoDBConnection.test_usage.connectionURL);
 
 var oldWorkspaceSchema = new Schema({
   name: Schema.Types.String,

--- a/src-server/mongodb-helper.js
+++ b/src-server/mongodb-helper.js
@@ -29,7 +29,11 @@ if(mongoDBService && mongoDBService.credentials && (mongoDBService.credentials.u
   }
 } else {
     logger.warn('mongoDB service not configured (or configured improperly), defaulting to local database');
-    connectionURL = 'mongodb://localhost:27017/atlas2';
+    connectionURL = process.env.MONGO_URL_ATLAS2 || 'mongodb://localhost:27017/atlas2';
 }
 
-module.exports = {connectionURL:connectionURL, options:options};
+module.exports = {
+  'atlas2': { connectionURL:connectionURL, options:options },
+  'test_duplication': { connectionURL:process.env.MONGO_URL_TEST_DUPLICATION || "mongodb://localhost:27017/test-duplication" },
+  'test_usage': { connectionURL:process.env.MONGO_URL_TEST_USAGE || "mongodb://localhost:27017/test-usage" }
+};


### PR DESCRIPTION
I believe these changes comprise everything necessary to Dockerize Atlas2 (#35).

[Docker Compose](https://docs.docker.com/compose/) is a tool for managing multi-container application stacks easily. This stack involves two containers. One is the Atlas2 code (see the `Dockerfile`). The other is a MongoDB instance.

Give it a try!

`docker-compose up` will build the Docker image and spin up the full stack locally. Visit http://localhost:6001 to test it out.

`docker-compose run web npm test` will spin up the full stack and run the test suite.

There is one test failure that only occurs inside the container that I do not yet understand. I suspect you might be able to shed some light on it before I begin troubleshooting:
```
127.0.0.1 - - [29/Jun/2017:05:44:09 +0000] "GET /img/595493a89a646500169af277.png HTTP/1.1" 200 - "-" "node-superagent/3.5.2"
[2017-06-29 05:44:09.275] [INFO] console -     1) download a png
[2017-06-29 05:44:09.276] [INFO] console -
[2017-06-29 05:44:09.276] [INFO] console -
[2017-06-29 05:44:09.276] [INFO] console -   17 passing (17s)
[2017-06-29 05:44:09.277] [INFO] console -   1 failing
[2017-06-29 05:44:09.277] [INFO] console -
[2017-06-29 05:44:09.277] [INFO] console -   1) Workspaces & maps download a png:
     AssertionError: expected 12812 to be within 15000..16000
```

Let me know what questions and concerns you have. I'm happy to make improvements as I find time..