### PR TITLE
Data no longer transient by default for Docker.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /npm-debug.log
 /backup/
 src-server/workspace/logs/wardleymaps.log
+/data/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,3 +16,5 @@ services:
       MONGO_URL_TEST_USAGE: "mongodb://mongo:27017/test-usage"
   mongo:
     image: mongo:3.0
+    volumes:
+      - ./data:/data/db:Z


### PR DESCRIPTION
By default, when a container is destroyed, its data is gone forever. I fear someone unfamiliar with Docker might not know that, spin this up, and accidentally destroy their data later by destroying the container. 

This commit allows the creation of a local data directory as default behavior to avoid the above scenario.